### PR TITLE
Add properties to geojson preview

### DIFF
--- a/previewers/betatest/js/map.js
+++ b/previewers/betatest/js/map.js
@@ -21,7 +21,20 @@ function writeContentAndData(data, fileUrl, file, title, authors) {
         attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
     }).addTo(map);
 
-    // add data to map and zoom to added features
-    var geoJson = L.geoJSON(geoJsonData).addTo(map);
+    // add data to map, including properties if set
+    var geoJson = L.geoJSON(geoJsonData, {
+        onEachFeature: function (feature, layer) {
+            if (feature.properties) {
+                var popupcontent = [];
+                for (var propName in feature.properties) {
+                    propValue = feature.properties[propName];
+                    popupcontent.push("<strong>" + propName + "</strong>: " + JSON.stringify(propValue, null, 2));
+                }
+                layer.bindPopup(popupcontent.join("<br />"));
+            }
+        }
+      }).addTo(map);
+
+    // zoom to added features
     map.fitBounds(geoJson.getBounds());
 }


### PR DESCRIPTION
Show the properties of the geoJson feature when a user clicks on the feature. Converts them to strings to handle cases where the property is a JSON object.

Here's a dataset with some files that can be used for testing, including some with and without properties. The "wikipedia.geojson" files has a JSON object in the properties: https://demo.dataverse.org/dataset.xhtml?persistentId=doi:10.70122/FK2/BMUCT5&version=2.0

![GeoJSON file preview showing properties](https://user-images.githubusercontent.com/6903515/176274559-1c619599-19be-4ac3-a03f-219e7efe7428.png)

![GeoJSON file preview with a JSON property](https://user-images.githubusercontent.com/6903515/176275113-066c76ad-b447-4d3b-9c94-0491f970885b.png)

