### PR TITLE
Remove spaces which break commands

### DIFF
--- a/5.2curlcommands.md
+++ b/5.2curlcommands.md
@@ -488,7 +488,7 @@ curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin
 ```
 
 ```bash
-curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \
 '{
   "displayName":"View Map",
   "description":"View a map of the file.",
@@ -518,7 +518,7 @@ As updates are made, they will be added to a /betatest sub-folder which will mak
 Adds properties to geojson preview
 
 ```bash
-curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \
 '{
   "displayName":"View Map",
   "description":"View a map of the file.",


### PR DESCRIPTION
A little cleanup to fix commands when copy and pasting