### PR TITLE
Add ELN based on the Zip previewer

### DIFF
--- a/5.2curlcommands.md
+++ b/5.2curlcommands.md
@@ -579,6 +579,46 @@ curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin
 }'
 ```
 
+### ELN Previewer Requirements:
+* Dataverse version v5.12+
+* Local file storage or S3 with direct download configured
+  * When using S3 storage: Extended CORS rule settings for the S3 bucket (see also: https://guides.dataverse.org/en/latest/developers/big-data-support.html#s3-direct-upload-and-download)
+    ```json
+    {
+    "CORSRules": [
+        {
+            "AllowedOrigins": ["*"],
+            "AllowedHeaders": ["*"],
+            "AllowedMethods": ["PUT", "GET", "HEAD"],
+            "ExposeHeaders": ["ETag", "Accept-Ranges", "Content-Range", "Content-Encoding"]
+        }
+    ]
+    }
+    ```
+
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \
+'{
+  "displayName":"Preview ELN file",
+  "description":"Preview the structure of an ELN Archive.",
+  "toolName":"zipPreviewer",
+  "scope":"file",
+  "types":["preview"],
+  "toolUrl":"https://gdcc.github.io/dataverse-previewers/previewers/betatest/ZipPreview.html",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"application/vnd.eln+zip"
+}'
+```
+
 ### NcML Previewer Requirements:
 * Dataverse version v5.13+ or NcML auxiliary files manually uploaded
 


### PR DESCRIPTION
Hello,

As discussed [here](https://github.com/IQSS/dataverse/issues/9363#issuecomment-1427542669), this PR adds support for ELN archive. An ELN archive is a zip file so the Zip previewer will work.

A few notes:

* I have _not_ tested this. You can download a .eln example [here](https://github.com/TheELNConsortium/TheELNFileFormat/tree/master/examples/elabftw).
* The file has windows line endings, can I make another PR after running `dos2unix` on it?
* The file has no headers/sections, I think it would help to have headers about the file type to improve readability.
* I'm targeting the `develop` branch because I'm guessing that's the correct branch to target, but a `CONTRIBUTING.md` file to help new contributors would be great.
* I have kept the toolname as ZipPreviewer, I'm not sure if it has to be changed or not, being unfamiliar with the codebase. Please advise.

Best,
~Nico


