### PR TITLE
handle missing persistentId along with empty one

### DIFF
--- a/previewers/betatest/js/retriever.js
+++ b/previewers/betatest/js/retriever.js
@@ -208,7 +208,7 @@ function startPreview(retrieveFile) {
         var versionText = $.i18n("versionText");
         var descriptionText = $.i18n("descriptionText");
         filePageUrl = queryParams.get("siteUrl") + "/file.xhtml?";
-        if (file.persistentId.length == 0) {
+        if (!("persistentId" in file) || file.persistentId.length == 0) {
             filePageUrl = filePageUrl + "fileId=" + file.id;
         } else {
             filePageUrl = filePageUrl + "persistentId=" + file.persistentId;


### PR DESCRIPTION
Dataverse ~5.14 appears to switch behavior from sending an empty file persistentId when one doesn't exist (draft or not using file pids). This PR makes the core retriever script check for both cases when deciding what form of file retrieval URL to create.