### PR TITLE
reduces max video width to match iframe width

### DIFF
--- a/previewers/betatest/css/preview.css
+++ b/previewers/betatest/css/preview.css
@@ -121,6 +121,7 @@ This has been done for the Rich Html Previewer, which also has the reverse issue
     margin: 20px auto;
     min-width: 600px;
     display: table;
+    max-width: 100%;
 }
 
 #logo {


### PR DESCRIPTION
when the video is too wide, it is not displayed in its entirety. By adjusting the maximum width of the preview, you can display the video more gracefully.

![3467bab7c8ce7e9c241f2b4ea6e9aeeeb971ead23b3dea80c41bc7b4de6a2dd3](https://github.com/gdcc/dataverse-previewers/assets/102069/0c403936-80f3-424c-8fca-27ca1bdde6a8)
