### PR TITLE
Local Install support

### DIFF
--- a/localinstall.sh
+++ b/localinstall.sh
@@ -1,21 +1,25 @@
 #!/bin/bash
 
-dirLocal=$(pwd)
-
 
 # go to the version folder
 if [ -z "$1" ]; then
-    echo "The variable is empty."
+    echo "The variable is empty. Provide the relative path to the previewer version you wish to make an all-local instance of."
     exit 1
 fi
 folder="$1"
 cd "${folder}"
 
-
+echo Downloading local copies of remote JavaScript libraries:
 sed -n 's/.*src="\(http[^"]*\)".*/\1/p' *.html | sort -u | sed -n 's/^\(.*\/\)*\(.*\)/sed -i \x27s,\0\,lib\/\2,\x27 *.html/p' > replace_js.sh
 sed -n 's/.*src="\(http[^"]*\)".*/\1/p' *.html | sort -u  > urls_js.txt
 source replace_js.sh
+cat urls_js.txt
 
+echo Downloading local copies of remote CSS files:
+sed -n 's/.*<link.*href="\(http[^"]*\)".*/\1/p' *.html | sort -u | sed -n 's/^\(.*\/\)*\(.*\)/sed -i \x27s,\0\,lib\/\2,\x27 *.html/p' > replace_css.sh
+sed -n 's/.*<link.*href="\(http[^"]*\)".*/\1/p' *.html | sort -u ?urls_css.txt
+source replace_css.sh
+cat urls_css.txt
 
 if [ ! -d ./lib ]; then
   mkdir ./lib
@@ -26,13 +30,22 @@ while read url; do
 done < "../urls_js.txt"
 
 
-cd ".."
+cd "${folder}"
 if [ ! -d ./css ]; then
   mkdir ./css
 fi
 cd ./css
 while read url; do
     wget --quiet $url
-done < "${dirLocal}/urls_css.txt"
+done < "../urls_css.txt"
 
+cd ..
+
+echo Cleaning Up...
+rm urls_js.txt
+rm urls_css.txt
+rm replace_js.sh
+rm replace_css.sh
+
+echo Done
 exit 0

--- a/localinstall.sh
+++ b/localinstall.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+dirLocal=$(pwd)
+
+
+# go to the version folder
+if [ -z "$1" ]; then
+    echo "The variable is empty."
+    exit 1
+fi
+folder="$1"
+cd "${folder}"
+
+
+sed -n 's/.*src="\(http[^"]*\)".*/\1/p' *.html | sort -u | sed -n 's/^\(.*\/\)*\(.*\)/sed -i \x27s,\0\,lib\/\2,\x27 *.html/p' > replace_js.sh
+sed -n 's/.*src="\(http[^"]*\)".*/\1/p' *.html | sort -u  > urls_js.txt
+source replace_js.sh
+
+
+if [ ! -d ./lib ]; then
+  mkdir ./lib
+fi
+cd ./lib
+while read url; do
+    wget --quiet $url
+done < "../urls_js.txt"
+
+
+cd ".."
+if [ ! -d ./css ]; then
+  mkdir ./css
+fi
+cd ./css
+while read url; do
+    wget --quiet $url
+done < "${dirLocal}/urls_css.txt"
+
+exit 0


### PR DESCRIPTION
A script that can be run on any version to change all external js and css links to relative ones that reference downloaded copies. Building on the download script from @BenediktMeierUIT.