### PR TITLE
Need md url for separate page even though it doesn't show

### DIFF
--- a/6.1curlcommands.md
+++ b/6.1curlcommands.md
@@ -1784,6 +1784,12 @@ curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin
       "httpMethod": "GET",
       "urlTemplate": "/api/v1/access/datafile/{fileId}?gbrecs=true",
       "timeOut": 3600
+    },
+    {
+      "name": "getDatasetVersionMetadata",
+      "httpMethod": "GET",
+      "urlTemplate": "/api/v1/datasets/{datasetId}/versions/{datasetVersion}",
+      "timeOut": 3600
     }
   ]
 }'


### PR DESCRIPTION
The metadata URL is needed - even though the voyager.js script doesn't populate the header (since it isn't viewable when the Voyager app covers it), the retriever.js script still gets the info from Dataverse via that URL.