### PR TITLE
Add audio/mp4 example

### DIFF
--- a/6.1curlcommands.md
+++ b/6.1curlcommands.md
@@ -255,6 +255,47 @@ curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin
   ]
 }'
 ```
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \
+'{
+  "displayName":"Play Audio",
+  "description":"Listen to an audio file.",
+  "toolName":"audioPreviewer",
+  "scope":"file",
+  "types":["preview"],
+  "toolUrl":"https://gdcc.github.io/dataverse-previewers/previewers/v1.4/AudioPreview.html",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"audio/mp4",
+  "allowedApiCalls": [
+    {
+      "name": "retrieveFileContents",
+      "httpMethod": "GET",
+      "urlTemplate": "/api/v1/access/datafile/{fileId}?gbrecs=true",
+      "timeOut": 3600
+    },
+    {
+      "name": "downloadFile",
+      "httpMethod": "GET",
+      "urlTemplate": "/api/v1/access/datafile/{fileId}?gbrecs=false",
+      "timeOut": 3600
+    },
+    {
+      "name": "getDatasetVersionMetadata",
+      "httpMethod": "GET",
+      "urlTemplate": "/api/v1/datasets/{datasetId}/versions/{datasetVersion}",
+      "timeOut": 3600
+    }
+  ]
+}'
+```
 
 ```bash
 curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \


### PR DESCRIPTION
audio/mp4 is replacing the deprecated audio/x-m4a MIME type - see https://mimetype.io/audio/x-m4a

- Closes #87