### PR TITLE
Add subtitles to video previews

### DIFF
--- a/previewers/betatest/js/video.js
+++ b/previewers/betatest/js/video.js
@@ -9,5 +9,104 @@ function translateBaseHtmlPage() {
 
 function writeContent(fileUrl, file, title, authors) {
     addStandardPreviewHeader(file, title, authors);
-    $(".preview").append($("<video/>").prop("controls",true).append($('<source/>').attr("src",fileUrl)));
+
+    const queryParams = new URLSearchParams(window.location.search.substring(1));
+    const id = queryParams.get("datasetid");
+    const siteUrl = queryParams.get("siteUrl");
+    const versionUrl = `${siteUrl}/api/datasets/${id}/versions/`
+        + queryParams.get("datasetversion");
+    const videoId =queryParams.get("fileid") * 1; // converted to number
+    const userLanguages = [...navigator.languages];
+    const locale = queryParams.get("locale");
+    if (locale && !userLanguages.includes(locale)) {
+        userLanguages.unshift(locale); // add as first element
+    }
+
+    $.ajax({
+        type: 'GET',
+        dataType: 'json',
+        crosssite: true,
+        url: versionUrl,
+        success: function(data, status) {
+            appendVideoElements(fileUrl, videoId, data.data.files, siteUrl, userLanguages);
+        },
+        error: function(request, status, error) {
+            // fallback to simple video element
+            $(".preview").append($("<video/>") .prop("controls", true) .append($('<source/>').attr("src", fileUrl)))
+        }
+    });
+}
+
+function appendVideoElements(fileUrl, videoId, files, siteUrl, userLanguages) {
+
+    const baseName = files // the video file name without extension
+        .find(item => item.dataFile.id === videoId)
+        .label.replace(/\.[a-z0-9]+$/i,'');
+
+    // find labels like "baseName.en.vtt", "baseName.de-CH.vtt" or "baseName.vtt"
+    const regex = new RegExp(`${baseName}(\\.([-a-z]+))?\\.vtt$`, 'i')
+
+    // create a map of URLs with their (optional) language
+    const subtitles = files
+        .filter(item => regex.test(item.label))
+        .reduce((map, item) => {
+            const lang = item.label.match(regex)[2];
+            const url = `${siteUrl}/api/access/datafile/${item.dataFile.id}?gbrecs=true&amp;key=93423e09-848c-47cb-a979-219dafcfa4da`;
+            map.set(url, lang);
+            return map;
+    }, new Map());
+
+    // sort subtitles by language value, 'de-CH' before 'de'
+    const sortedSubtitles = new Map([...subtitles.entries()].sort((a, b) => {
+        if (!a[1]) return 1;
+        if (!b[1]) return -1;
+        if (a[1].startsWith(b[1])) return -1;
+        if (b[1].startsWith(a[1])) return 1;
+        return a[1].localeCompare(b[1]);
+    }));
+
+    // determine default track
+    let defaultTrackUrl = null;
+    let trackUrlWithoutLang = null;
+    loop: for (const lang of userLanguages) {
+        for (const [url, trackLang] of sortedSubtitles) {
+            if (trackLang) {
+                if (trackLang === lang || trackLang.startsWith(lang.replace(/-.*/, ''))) {
+                    defaultTrackUrl = url;
+                    break loop;
+                }
+            } else {
+                trackUrlWithoutLang = url;
+            }
+        }
+    }
+    if (!defaultTrackUrl) {
+        defaultTrackUrl = trackUrlWithoutLang;
+    }
+    if (!defaultTrackUrl && subtitles) {
+        defaultTrackUrl = subtitles.values().next().value;
+    }
+
+    const videoElement = $("<video/>")
+        .prop("controls", true)
+        .append($('<source/>').attr("src", fileUrl));
+
+    sortedSubtitles.forEach((trackLang, url) => {
+        const trackElement = $('<track/>')
+            .attr("kind", "subtitles")
+            .attr("src", url);
+        if (trackLang) {
+            trackElement
+                .attr("label", trackLang)
+                .attr("srclang", trackLang);
+        } else {
+            trackElement.attr("label", "???");
+        }
+        if (url === defaultTrackUrl) {
+            trackElement.attr("default", true);
+        }
+        videoElement.append(trackElement);
+    });
+
+    $(".preview").append(videoElement);
 }


### PR DESCRIPTION
How to test
* Create a dataset with a video, for example from https://toolsfairy.com/video-test/sample-mp4-files#
*  Add vtt files, an [example](https://gist.github.com/samdutton/ca37f3adaf4e23679957b8083e061177). Publish the changes.
* These files should have the same base name as the video, tried with extensions
  `.vtt`, `.de.vtt`, `.en-US.vtt`, `en.vtt`, `.fr.vtt`
* When we open the preview in a new window we can test with `&locale=de-CH` and with `&locale=fr` (these don't have exact matches with the extensions)
* Note the highlighted language in the result (Chrome has a more complex menu than Firefox shown below)
  ![image](https://github.com/user-attachments/assets/e919c95c-dfff-4fd3-9428-6c135dc02572) ![image](https://github.com/user-attachments/assets/ed6ba146-8dcd-4ef6-a7f8-6442f949bdfe)
* Without the locale (or an invalid value) the previewer falls back to preferences configured in the browser
* Without a match the previewer falls back to the `???` track (if a vtt files is provided without language component), or the first.