### PR TITLE
video subtitles: cross-origin attribute for object storage

### DIFF
--- a/previewers/betatest/js/video.js
+++ b/previewers/betatest/js/video.js
@@ -101,6 +101,7 @@ function appendVideoElements(fileUrl, videoId, files, siteUrl, userLanguages, ap
     }
 
     const videoElement = $("<video/>")
+        .attr("crossorigin", "anonymous") // required for getting subtitles from object storage
         .prop("controls", true)
         .append($('<source/>').attr("src", fileUrl));
 


### PR DESCRIPTION
cross-origin attribute for object storage

Follow up of #100, #91 and #97 for https://github.com/IQSS/dataverse/issues/11041

Sync with https://github.com/DANS-KNAW/dataverse-previewers/blob/1.4-DANS-PATCH-1/previewers/v1.4-DANS-PATCH-2/js/video.js