### PR TITLE
Update spreadsheet.js to handle quotes cells

### DIFF
--- a/previewers/betatest/js/spreadsheet.js
+++ b/previewers/betatest/js/spreadsheet.js
@@ -23,7 +23,8 @@ function writeContent(fileUrl, file, title, authors) {
           var csv = e.target.result;
           var data = Papa.parse(csv, {
             header: true,
-            skipEmptyLines: true
+            skipEmptyLines: true,
+            quoteChar:'"'
           })
 
           handsontableContainer.innerHTML = '';

--- a/previewers/betatest/js/spreadsheet.js
+++ b/previewers/betatest/js/spreadsheet.js
@@ -24,7 +24,8 @@ function writeContent(fileUrl, file, title, authors) {
           var data = Papa.parse(csv, {
             header: true,
             skipEmptyLines: true,
-            quoteChar:'"'
+            quoteChar:'"',
+            delimitersToGuess:['\t',',']
           })
 
           handsontableContainer.innerHTML = '';


### PR DESCRIPTION
As reported in https://groups.google.com/d/msgid/dataverse-community/ef52665f-2348-413b-9181-0aad860316c1n%40googlegroups.com?utm_medium=email&utm_source=footer, the current previewer isn't handling cells that are in quotes (and have a comma inside them). 

This PR tries to address that by setting delimitersToGuess: to just support the '\t' and ',' delimiters we use for tsv/csv files. The PR also sets the quoteChar to '"'. It's not clear that's needed.

I did some basic testing at QDR and these changes fix the problem in email and don't appear to break parsing of existing csv/tsv files that don't have commas inside quoted tab separated cells.