### PR TITLE
Add DOCTYPE to avoid quirks mode

### DIFF
--- a/previewers/betatest/AudioPreview.html
+++ b/previewers/betatest/AudioPreview.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <head>

--- a/previewers/betatest/HtmlPreview.html
+++ b/previewers/betatest/HtmlPreview.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <head>

--- a/previewers/betatest/HypothesisPreview.html
+++ b/previewers/betatest/HypothesisPreview.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <head>

--- a/previewers/betatest/ImagePreview.html
+++ b/previewers/betatest/ImagePreview.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <head>

--- a/previewers/betatest/MapPreview.html
+++ b/previewers/betatest/MapPreview.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
     <head>
         <meta charset="utf-8">

--- a/previewers/betatest/MapRasterPreview.html
+++ b/previewers/betatest/MapRasterPreview.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
     <head>
         <meta charset="utf-8">

--- a/previewers/betatest/MapShpPreview.html
+++ b/previewers/betatest/MapShpPreview.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
     <head>
         <meta charset="utf-8">

--- a/previewers/betatest/MdPreview.html
+++ b/previewers/betatest/MdPreview.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <head>

--- a/previewers/betatest/NcmlPreview.html
+++ b/previewers/betatest/NcmlPreview.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <head>

--- a/previewers/betatest/PDFPreview.html
+++ b/previewers/betatest/PDFPreview.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <head>

--- a/previewers/betatest/ROCrate.html
+++ b/previewers/betatest/ROCrate.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <head>

--- a/previewers/betatest/RichHtmlPreview.html
+++ b/previewers/betatest/RichHtmlPreview.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8" />

--- a/previewers/betatest/SpreadsheetPreview.html
+++ b/previewers/betatest/SpreadsheetPreview.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <head>

--- a/previewers/betatest/TextPreview.html
+++ b/previewers/betatest/TextPreview.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <head>

--- a/previewers/betatest/VideoPreview.html
+++ b/previewers/betatest/VideoPreview.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <head>

--- a/previewers/betatest/X3DPreview.html
+++ b/previewers/betatest/X3DPreview.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <head>

--- a/previewers/betatest/ZipPreview.html
+++ b/previewers/betatest/ZipPreview.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <head>


### PR DESCRIPTION
Chrome reports an issue on the previewer pages due to lack of an initial DOCTYPE - see https://developer.chrome.com/docs/lighthouse/best-practices/doctype?utm_source=devtools&utm_campaign=stable