### PR TITLE
Collapse RichHtmlPreview warning + buttons after user picks a mode

### DIFF
--- a/previewers/betatest/js/richhtml.js
+++ b/previewers/betatest/js/richhtml.js
@@ -26,12 +26,12 @@ function writeContentAndData(data, fileUrl, file, title, authors) {
         subheader = $('<div/>').appendTo(header).addClass('center');
         subheader.append($("<div/>").addClass("btn btn-default")
              .html($('<a/>').html( $.i18n('displayWithRichContent'))
-                 .click(function(){console.log('Click');$('.preview').html(theData);})
+                 .click(function(){console.log('Click');$('.preview').html(theData);header.remove();})
              )
         );
         subheader.append($("<div/>").addClass("btn btn-default")
              .html($('<a/>').html( $.i18n('displayWithoutRichContent'))
-                 .click(function(){console.log('Click');$('.preview').html(filterXSS(theData,options));})
+                 .click(function(){console.log('Click');$('.preview').html(filterXSS(theData,options));header.remove();})
              )
         );
     } else {


### PR DESCRIPTION
## Summary
- Fixes #149.
- After the user clicks either "Display With Rich Content" or "Display Without Rich Content", the warning header (warning text + both buttons) is removed so it no longer consumes ~100–150 px above the preview for the rest of the session.
- Applied to `previewers/betatest/js/richhtml.js` only, per CONTRIBUTING.md.

## Change
Two-character (well, two-call) edit — `header.remove()` is appended to each click handler. `header` is already in scope as a `var` declared a few lines earlier.

```diff
-                 .click(function(){console.log('Click');$('.preview').html(theData);})
+                 .click(function(){console.log('Click');$('.preview').html(theData);header.remove();})
...
-                 .click(function(){console.log('Click');$('.preview').html(filterXSS(theData,options));})
+                 .click(function(){console.log('Click');$('.preview').html(filterXSS(theData,options));header.remove();})
```

I intentionally kept this PR minimal: just the collapse fix. The shortened warning text and an optional "Switch view" toggle mentioned in the issue are deferred — happy to follow up in a separate PR if the maintainers want them.

## Test plan
- [ ] Upload an HTML file containing `<script>` or `<head>` to a Dataverse instance and open its preview pane.
- [ ] Verify the warning header + both buttons appear before any click.
- [ ] Click "Display With Rich Content" → verify the header disappears and the rich content renders alone.
- [ ] Click "Display Without Rich Content" (fresh load) → verify the header disappears and the XSS-filtered content renders alone.
- [ ] Upload an HTML file with no `<script>`/`<head>` and verify the previewer still renders directly with no warning (unchanged behaviour).