### PR TITLE
Update GeoTIFF and SHP previewers

### DIFF
--- a/6.1curlcommands.md
+++ b/6.1curlcommands.md
@@ -1349,7 +1349,7 @@ curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin
 
 ### ESRI Shape Previewer
 
-This previewer includes a hard-coded file size limit of a zipped shp file of 20 MB (larger zips will not be loaded). If you want to change this limit you can change the value in "previewers/v1.5/js/mapshp.js", but then you have to host the customised previewer yourself (e.g. via github pages). Instructions on how to build external tools yourself can be found here: https://guides.dataverse.org/en/latest/api/external-tools.html. 
+Works with zipped shapefiles in any known projection. This previewer includes a hard-coded file size limit of a zipped shp file of 50 MB (larger zips will not be loaded). If you want to change this limit you can change the value in "previewers/betatest/js/mapshp.js", but then you have to host the customised previewer yourself (e.g. via github pages). Instructions on how to build external tools yourself can be found here: https://guides.dataverse.org/en/latest/api/external-tools.html. 
 
 ```bash
 curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \
@@ -1359,7 +1359,7 @@ curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin
   "toolName":"mapShpPreviewer",
   "scope":"file",
   "types":["preview"],
-  "toolUrl":"gdcc.github.io/dataverse-previewers/previewers/v1.5/MapShpPreview.html",
+  "toolUrl":"https://gdcc.github.io/dataverse-previewers/previewers/betatest/MapShpPreview.html",
   "toolParameters": {
       "queryParameters":[
         {"fileid":"{fileId}"},
@@ -1393,21 +1393,19 @@ curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin
 }'
 ```
 
-### GeoTIFF Previewer
+### GeoTIFF + TIFF Previewer
 
-Please note that the Geotiff Previewer tries to display ALL image/tiff files in a map (because there is no own mimetype for Geotiffs at the moment). Therefore please only use it if you want to use Geotiffs only. As soon as there is an own mimetype for Geotiffs, this will be updated.
-
-Limits are also defined for previewing raster files. Besides the file size limit (20 MB), a column and row limit (50,000) and a loading timeout (30 seconds) are defined. In case of an unsupported GeoTIFF (e.g. no projection specified), an error message is displayed after 30 seconds stating that the tiff image cannot be loaded. These limits can be adjusted as needed in previewers/v1.5/js/mapraster.js, although this adjusted version must then also be hosted by yourself (e.g. via github pages). Instructions on how to build external tools yourself can be found here: https://guides.dataverse.org/en/latest/api/external-tools.html.  
+This previewer reads GeoTIFF and "standard" TIFF files. It is recommended to save GeoTIFFs as COG (cloud-optimized GeoTIFF), for example using gdal_translate. This automatically adds overviews (pyramid layers) to GeoTIFFs and splits them into tiles (blocks), ensuring they are displayed efficiently. If color maps (color palettes) are defined in the GeoTIFF for grayscale rasters (1 band), they are rendered in color. Any projection should be supported, as long as it is correctly defined and known (for rendering, the data is automatically reprojected to epsg:3857). GeoTIFFs without overviews are only loaded if they are 50 MB or smaller. This file size limit can be adjusted as needed in previewers/betatest/js/mapraster.js, although this adjusted version must then also be hosted by yourself (e.g. via github pages). Instructions on how to build external tools yourself can be found here: https://guides.dataverse.org/en/latest/api/external-tools.html.  
 
 ```bash
 curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \
 '{
   "displayName":"View Map",
   "description":"View a map of the file.",
-  "toolName":"mapShpPreviewer",
+  "toolName":"mapTiffPreviewer",
   "scope":"file",
   "types":["preview"],
-  "toolUrl":"gdcc.github.io/dataverse-previewers/previewers/v1.5/MapRasterPreview.html",
+  "toolUrl":"https://gdcc.github.io/dataverse-previewers/previewers/betatest/MapRasterPreview.html",
   "toolParameters": {
       "queryParameters":[
         {"fileid":"{fileId}"},

--- a/previewers/betatest/MapRasterPreview.html
+++ b/previewers/betatest/MapRasterPreview.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <html>
     <head>
         <meta charset="utf-8">
@@ -15,20 +14,42 @@
         <!-- Optional theme -->
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap-theme.min.css"
             integrity="sha384-6pzBo3FDv/PJ8r2KRkGHifhEocL+1X2rVCTTkUfGk7/0pbek5mMa1upzvWbrUbOZ" crossorigin="anonymous">
-        <!-- Leaflet -->
-        <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" 
-            integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A==" crossorigin="anonymous"/>
-        <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js" 
-            integrity="sha512-XQoYMqMTK8LvdxXYG3nZ448hOEQiglfqkJs1NOQV44cWnUrBc8PkAOcXy20w0vlaXaVUearIOBhiXZ5V3ynxwA==" crossorigin="anonymous"></script>
-        <link type="text/css" rel="stylesheet" href="css/preview.css" />
-        <!--drawing raster-->
-        <script src="https://unpkg.com/georaster@1.6.0/dist/georaster.browser.bundle.min.js" 
-            integrity="sha512-SkPYBKB00LoLZf/I0yaoIwp88e7E+X5iFliB4n84vmzhjdEdEla/vouiA0Nr6aLHoRCB54DK8CCynKNd0DfCSg==" crossorigin="anonymous"></script>
-        <script src="https://unpkg.com/georaster-layer-for-leaflet@3.10.0/dist/v3/webpack/bundle/georaster-layer-for-leaflet.min.js" 
-            integrity="sha512-bNJ+bvpXepatbIMeaida52kR2AT5lr6a9dTfb/OB0c/3O2KzUrdUi3Gtri0zvJUbfKgmG+wN3GKTkBi/6OkVVA==" crossorigin="anonymous"></script>
+
+        <!-- proj4 -->
+        <script
+          src="https://cdn.jsdelivr.net/npm/proj4@2.19.10/dist/proj4.js"
+          integrity="sha512-QXAXxYhXWvAc5fA3edU2rOQANjhwKAAlqz1WEhh/FXzODQoqVb9PkHqJcCG7aFoJpN0VQMNnxOBztoIQOcEO5w=="
+          crossorigin="anonymous">
+        </script>
+        
+        <!-- open layers -->
+        <link rel="stylesheet" 
+            href="https://cdn.jsdelivr.net/npm/ol@10.9.0/ol.css" 
+            integrity="sha384-Jpg1uvTciFJuHq+90Ly0/2SKRT9yS5OhbIN5FuFoFWji9fc44ok8xxO88CJi8Z5W" 
+            crossorigin="anonymous">
+        
+        <script src="https://cdn.jsdelivr.net/npm/ol@10.9.0/dist/ol.js" 
+            integrity="sha384-H9f6d9zpuIdeGwVsGIPSbRgWKZ8WRk2C1K7GxlC61fe5qjRCL/5Qvp2wUvUVDS8v" 
+            crossorigin="anonymous">
+        </script>
+        
+        <!-- geotiff.js -->
+        <script src="https://cdn.jsdelivr.net/npm/geotiff@3.0.5/dist-browser/geotiff.min.js" 
+            integrity="sha384-DO8rKWcIW99TbR6KkYDH8iWvF+phDTyWcniS1ZemcLljgA1LVIbw09us1D0jiAN9" 
+            crossorigin="anonymous">
+        </script>
+
+        <!-- UTIFF -->
+        <script src="https://cdn.jsdelivr.net/npm/utif@3.1.0/UTIF.js" 
+            integrity="sha384-RyBmXHdfZ/Uon+ud+/AqSyWpUWnKYt2tkRG/P4gWoRUGDU+qIAV3tGBPNlYTBZEF" 
+            crossorigin="anonymous">
+        </script>
+
         <!-- spinner-->
         <script src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.js" 
-            integrity="sha512-C7tgVIfPE0ivBKcs2WstAh5y7Njir2odGBjnuIa64SmVzZIoTb8kRrNursRzEv4bNcesPywtVAXqH1GmqRBmpg==" crossorigin="anonymous"></script>
+            integrity="sha512-C7tgVIfPE0ivBKcs2WstAh5y7Njir2odGBjnuIa64SmVzZIoTb8kRrNursRzEv4bNcesPywtVAXqH1GmqRBmpg==" 
+            crossorigin="anonymous">
+        </script>
     </head>
 
     <body class="container">
@@ -41,7 +62,7 @@
             <div class='preview-container'>
                 <div class='preview-header'></div>
                 <div class='preview'>
-                    <div id="map" style="width: 800px; height: 500px;"></div>
+                    <div id="map" style="width: 900px; height: 600px;"></div>
                 </div>
             </div>
         </main>

--- a/previewers/betatest/MapShpPreview.html
+++ b/previewers/betatest/MapShpPreview.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <html>
     <head>
         <meta charset="utf-8">
@@ -12,20 +11,22 @@
         <!-- Latest compiled and minified CSS -->
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css"
             integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
+
         <!-- Optional theme -->
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap-theme.min.css"
             integrity="sha384-6pzBo3FDv/PJ8r2KRkGHifhEocL+1X2rVCTTkUfGk7/0pbek5mMa1upzvWbrUbOZ" crossorigin="anonymous">
+
         <!-- Leaflet -->
         <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" 
             integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A==" crossorigin="anonymous"/>
         <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js" 
             integrity="sha512-XQoYMqMTK8LvdxXYG3nZ448hOEQiglfqkJs1NOQV44cWnUrBc8PkAOcXy20w0vlaXaVUearIOBhiXZ5V3ynxwA==" crossorigin="anonymous"></script>
         <link type="text/css" rel="stylesheet" href="css/preview.css" />
+
         <!-- ShapeJS-->
-        <script src="https://cdn.rawgit.com/calvinmetcalf/shapefile-js/gh-pages/dist/shp.js" 
-            integrity="sha512-RT1pg7PTZ3R8amXsuOV3aJAVjBxenRKgmLg68ZMN6RMeRQWTrbxnPszM9+6/UVkmuRYaM0cg6R5lqwQJfJhVUw==" crossorigin="anonymous"></script>
-        <script src="https://cdn.rawgit.com/calvinmetcalf/leaflet.shapefile/gh-pages/leaflet.shpfile.js" 
-            integrity="sha512-pZ4bO+wYEIa3xGxktY7N3CDNF4QfBlzmps/cqfOY2SZA7v1kH/y7rxQaqvk1W31NqjVTcyZkV0fPaOBGcCTOgg==" crossorigin="anonymous"></script>
+        <script src="https://unpkg.com/shpjs@6.2.0/dist/shp.min.js" 
+            integrity="sha512-uew7ZF76ydiw8bbr370XgfbQ7+B9eHMWiFbh8MiZ0Y9772nN12Wx6I913bvWb3V8GZbhxt/pBEMBHnjrz1U7GQ==" crossorigin="anonymous"></script>
+
         <!-- spinner-->
         <script src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.js" 
             integrity="sha512-C7tgVIfPE0ivBKcs2WstAh5y7Njir2odGBjnuIa64SmVzZIoTb8kRrNursRzEv4bNcesPywtVAXqH1GmqRBmpg==" crossorigin="anonymous"></script>
@@ -42,7 +43,7 @@
             <div class='preview-container'>
                 <div class='preview-header'></div>
                 <div class='preview'>
-                    <div id="map" style="width: 800px; height: 500px;"></div>
+                    <div id="map" style="width: 900px; height: 600px;"></div>
                 </div>
             </div>
         </main>

--- a/previewers/betatest/js/mapraster.js
+++ b/previewers/betatest/js/mapraster.js
@@ -2,12 +2,8 @@ $(document).ready(function() {
     startPreview(false);   
 });
 
-// set limits
-const file_size_limit = 15; // in MB
-const row_col_limit = 50000; // number of columns or rows
-const load_timeout = 30; // in seconds
-
-var raster_loaded = false;
+// set file size limit for non tiled tiff
+const fileSizeLimit = 50; // in MB
 
 // enable spinner
 var target = document.getElementById('map');
@@ -18,57 +14,459 @@ function translateBaseHtmlPage() {
     $( '.mapPreviewText' ).text( mapPreviewText );
 }
 
-function writeContent(fileUrl, file, title, authors) {
+async function loadMetadata(metadataUrl) {
+  const response = await fetch(metadataUrl);
+
+  if (!response.ok) {
+    show_error(`request on metadata failed`);
+    throw new Error(`HTTP Error: ${response.status}`);    
+  }
+
+  const metadata = await response.json();
+
+  return metadata;
+}
+
+async function registerEPSG(epsg) {
+
+    // Schon bekannt?
+    if (ol.proj.get("EPSG:" + epsg)) {
+        return;
+    }
+
+    const response = await fetch(
+        `https://epsg.io/${epsg}.proj4`
+    );
+
+    if (!response.ok) {
+        show_error(`EPSG-Code ${epsg.toString()} not found`);
+        throw new Error("EPSG-Code not found");        
+    }
+
+    const def = (await response.text()).trim();
+
+    proj4.defs("EPSG:" + epsg, def);
+    ol.proj.proj4.register(proj4);
+}
+
+async function getRasterInfo(url) {
+    try {
+        const tiff = await GeoTIFF.fromUrl(url);
+        const image = await tiff.getImage();
+
+        return image;
+
+    } catch (e) {
+        //console.log("no valid TIFF file", e);
+        show_error(`no valid TIFF file`);
+        return false;
+    }
+}
+
+
+async function checkIfGeoTiff(image) {
+
+    console.log(image);
+
+    try {
+        const geoKeys = image.getGeoKeys();
+
+        const isGeoTIFF =
+            Object.keys(image.getFileDirectory()).some(k =>
+                [
+                    "ModelPixelScale",
+                    "ModelTiepoint",
+                    "ModelTransformation"
+                ].includes(k)
+            ) ||
+            Object.keys(image.getGeoKeys()).length > 0;
+
+        console.log({
+            width: image.getWidth(),
+            height: image.getHeight(),
+            tiled: image.isTiled,
+            bands: image.getSamplesPerPixel(),
+            geoKeys,
+            isGeoTIFF
+        });
+
+        // add epsg to ol
+        ol.proj.proj4.register(proj4);
+
+        const epsg =
+            geoKeys.ProjectedCSTypeGeoKey ??
+            geoKeys.GeographicTypeGeoKey;
+
+        if (epsg) {
+            await registerEPSG(epsg);
+        }
+    
+        return isGeoTIFF;
+
+
+    } catch (e) {
+        console.log("no GeoTIFF file", e);
+        return false;
+    }    
+}
+
+async function checkPyramidsTiles(url){
+
+    try {
+        // check if overviews exists, wich are not subsets or bands
+
+        const tiff = await GeoTIFF.fromUrl(url);
+        const count = await tiff.getImageCount();
+
+        let hasOverviews = false;
+        let isTiled = false;
+
+        let hasOverviewsAndTiles = false;
+
+        if (count > 1) {
+            const full = await tiff.getImage(0);
+        
+            for (let i = 1; i < count; i++) {
+                const overview = await tiff.getImage(i);
+            
+                if (overview.getWidth() < full.getWidth() && overview.getHeight() < full.getHeight()) {
+                    hasOverviews = true;
+                    break;
+                }
+            }
+        }
+
+        const image = await tiff.getImage();
+
+        isTiled = image.isTiled;
+
+        if(hasOverviews == true && isTiled == true){
+            hasOverviewsAndTiles = true;
+        }
+
+        return hasOverviewsAndTiles;
+
+    } catch (e) {
+        console.log("no pyramide found", e);
+        return false;
+    }
+
+}
+
+async function checkMinMax(image) {
+    const md = image.getGDALMetadata();
+    const fd = image.getFileDirectory();
+
+    let min = null;
+    let max = null;
+
+    // 1. GDAL-Statistiken
+    if (md?.STATISTICS_MINIMUM && md?.STATISTICS_MAXIMUM) {
+        min = parseFloat(md.STATISTICS_MINIMUM);
+        max = parseFloat(md.STATISTICS_MAXIMUM);
+    }
+    // 2. TIFF-Tags
+    else if (fd.SMinSampleValue !== undefined && fd.SMaxSampleValue !== undefined) {
+        min = fd.SMinSampleValue;
+        max = fd.SMaxSampleValue;
+    }
+    else if (fd.MinSampleValue !== undefined && fd.MaxSampleValue !== undefined) {
+        min = fd.MinSampleValue;
+        max = fd.MaxSampleValue;
+    }
+
+    // number of bands
+    const bands = image.getSamplesPerPixel();
+
+    return [min,max,bands];
+
+}
+
+async function getMinMax(image) {
+    
+    const noData = Number(image.getGDALNoData());
+
+    // small sample 512x512 Pixel
+    const width = image.getWidth();
+    const height = image.getHeight();
+
+    const raster = await image.readRasters({
+        samples: [0],
+        window: [
+            0,
+            0,
+            Math.min(width, 512),
+            Math.min(height, 512)
+        ]
+    });
+
+    let min = null;
+    let max = null;
+
+    for (const value of raster[0]) {
+
+        if (
+            Number.isNaN(value) ||
+            value === noData
+        ) {
+            continue;
+        }
+
+        min = Math.min(min, value);
+        max = Math.max(max, value);
+    }
+
+    return [min,max];
+}
+
+
+function loadGeoTiff(sources,style,normalize){
+    const osm = new ol.layer.Tile({
+        source: new ol.source.OSM()
+    });
+
+    console.log("normalize", normalize);
+
+    const source = new ol.source.GeoTIFF({
+        interpolate: false,
+        normalize: normalize,
+        sources: sources,
+    });
+
+    // WebGL-optimierter Kachel-Layer aus dem Bundle
+    const tileLayer = new ol.layer.WebGLTile({
+        source: source, 
+        style:style,
+        interpolate: false
+    });
+    
+
+    const map = new ol.Map({
+        target: 'map',
+        layers: [osm, tileLayer],
+        // Automatischer Zoom und Zentrierung auf die Geometrie der TIF-Datei
+        view: source.getView()
+    });
+
+
+    // fit to layer
+    source.on('change', async () => {
+        if (source.getState() === 'ready') {
+            const view = await source.getView();
+        
+            map.getView().fit(view.extent, {
+                padding: [20, 20, 20, 20],
+                duration: 100
+            });
+        }
+    });
+
+}
+
+async function loadTiff(url) {
+    const buffer = await fetch(url).then(r => r.arrayBuffer());
+
+    const ifds = UTIF.decode(buffer);
+    UTIF.decodeImage(buffer, ifds[0]);
+
+    const rgba = UTIF.toRGBA8(ifds[0]);
+
+    const canvas = document.createElement("canvas");
+    canvas.width = ifds[0].width;
+    canvas.height = ifds[0].height;
+
+    const ctx = canvas.getContext("2d");
+    const imageData = ctx.createImageData(canvas.width, canvas.height);
+
+    imageData.data.set(rgba);
+    ctx.putImageData(imageData, 0, 0);
+
+    // In das map-Div einfügen
+    const map = document.getElementById("map");
+
+    // Vorherigen Inhalt entfernen
+    map.innerHTML = "";
+
+    // Optional: Canvas an den Container anpassen
+    canvas.style.maxWidth = "100%";
+    canvas.style.maxHeight = "100%";
+    canvas.style.display = "block";
+    canvas.style.margin = "0 auto";
+
+    map.appendChild(canvas);
+}
+
+async function getColors(colorMap) {
+    const colors = [];
+
+    const entries = colorMap.length / 3;
+
+    for (let i = 0; i < entries; i++) {
+        const r = Math.round(colorMap[i] / 257);
+        const g = Math.round(colorMap[i + entries] / 257);
+        const b = Math.round(colorMap[i + 2 * entries] / 257);
+
+        colors.push([r, g, b, 1]);
+    }
+
+    return colors;
+}
+
+async function getFileSize(){
+    
+    // size via header (replaced with metadata...)
+    //  fetch(fileUrl, { method: "HEAD" })
+    //    .then(r => console.log(r.headers.get("Content-Length")));
+
+    const fileid = queryParams.fileid;
+    const datasetMetadataUrl = queryParams.versionUrl;
+
+    // metadata of dataset
+    const metadata = await loadMetadata(datasetMetadataUrl);
+
+    // metadata of all files including name and id
+    const filesMetadata = metadata.data.files;
+
+    // metadata of tiff what to preview
+    const fileMetadata = filesMetadata.find(f => f.dataFile.id === fileid);
+
+    // get file name and size (mb) of tiff
+    const fileName = fileMetadata.dataFile.filename;
+    const fileSize = Math.round(fileMetadata.dataFile.filesize/(1024**2));
+    console.log(fileName, fileSize);
+
+    return fileSize
+}
+
+async function writeContent(fileUrl, file, title, authors) {
     addStandardPreviewHeader(file, title, authors);
 
-    //check file size
-    const url_to_file_info = fileUrl.replace("access/data","").replace("file","files"); 
+    // get file size
+    const fileSize = await getFileSize();    
 
-    $.getJSON(url_to_file_info, function( data ) {
-        const file_size = data.data.dataFile.filesize/(1024**2);
+    // get info of raster
+    const imageInfo = await getRasterInfo(fileUrl);
 
-        if (file_size > file_size_limit){
-            show_error(`The file is too big to be displayed (limit is ${file_size_limit.toString()} MB)`);
+    // exit on invalid tiff
+    if(!imageInfo){return}
+    
+    // check if GeoTiff
+    const isGeoTiff = await checkIfGeoTiff(imageInfo);
+    
+    if(isGeoTiff){
+
+        // check for pyramides and tile
+        const hasOverviewsAndTiles = await checkPyramidsTiles(fileUrl);
+
+        if (hasOverviewsAndTiles == false && fileSize > fileSizeLimit){
+            show_error(`The file is too big to be displayed (limit is ${fileSizeLimit.toString()} MB).
+                \nLarger GeoTIFFs can only be displayed if they use pyramids and tiles, such as COG (Cloud-Optimized GeoTIFFs).`);
         }else{
-            // initialize the map
-            var map = L.map('map').fitWorld(); 
 
-            // add OpenStreetMap basemap
-            L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
-                attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-            }).addTo(map);
+            // check min, max and bands
+            let [min,max,bands] = await checkMinMax(imageInfo);            
 
-            // load the raster
-            fetch(fileUrl)
-            .then(response => response.arrayBuffer())
-            .then(arrayBuffer => {
-                parseGeoraster(arrayBuffer).then(georaster => {
-                    raster_loaded = true;
-                    // check row, col limits
-                    if (georaster.width > row_col_limit || georaster.height > row_col_limit){
-                        show_error(`The number of rows or columns is too high to be displayed (limit is ${row_col_limit.toString()})`);
-                    // draw the raster
-                    }else{
-                    	//console.log("georaster:", georaster);
+            // get min maxif in case of one bands
+            if(bands==1 && min == null){
+                [min,max] = await getMinMax(imageInfo);
+            } 
+            //console.log(min,max,bands);
 
-                    	var layer = new GeoRasterLayer({
-                    	    georaster: georaster,
-                    	    //debugLevel: 2,
-                    	    opacity: 1,
-                    	    resolution: 256
-                    	});
-                    	layer.addTo(map);	
-                    	map.fitBounds(layer.getBounds());
+            // set nodata
+            const noData = Number(imageInfo.getGDALNoData());
 
-                    	// disable spinner
-                    	spinner.stop();
-                    }
-                });
-            // check if raster is loaded    
-            }).then(checkIfLoaded());                
+            let normalize = true;
+
+            // set source
+            let sources = [{url: fileUrl, noData:noData}];
+
+            let style = null;
+
+            // set default color ramp for greyscale
+            if (bands==1){
+                style = {
+                  color: [
+                    "case",
+                
+                    // NoData transparent
+                    // note: ol added band 2 as nodata mask
+                    ["==", ["band", 2], 0],
+                    [0, 0, 0, 0],
+                
+                    // Farbverlauf
+                    [
+                      "interpolate",
+                      ["linear"],
+                      ["band", 1],
+                    
+                      0,     [30, 20, 60, 1],
+                      0.25,  [80, 40, 120, 1],
+                      0.5,   [180, 70, 80, 1],
+                      0.75,  [240, 150, 40, 1],
+                      1,     [255, 240, 180, 1]
+                    ]
+                  ]
+                };
+            }
+
+            // check colormap           
+            const fileDirectory = imageInfo.getFileDirectory();
+            const colorMap = await fileDirectory.loadValue("ColorMap");
+
+            if (colorMap!=null){
+
+                const colors = await getColors(colorMap);
+            
+                normalize = false;
+
+                style = {
+                  color: [
+                    "case",
+                    // NoData transparent
+                    // note: ol added band 2 as nodata mask
+                    ["==", ["band", 2], 0],
+                    [0, 0, 0, 0],
+
+                    // pallete colors
+                    [
+                      "palette",
+                      ["band",1],
+                      colors
+                    ]
+                  ]
+                };
+            }
+            // add min max in case of 1 bands for stretching
+            else if(bands==1 && min != null && max != null){
+                sources=[{ 
+                    url: fileUrl,
+                    min: min,
+                    max: max 
+                }];
+            }
+
+            // load geotiff
+            loadGeoTiff(sources,style,normalize);
+        }    
+
+    // else it is a "normal" tiff
+    }else{   
+        
+        // check file size
+        if (fileSize > fileSizeLimit){
+            show_error(`The file is too big to be displayed (limit is ${fileSizeLimit.toString()} MB).`);
+        }else{
+            loadTiff(fileUrl);
         }
-    })
+    }
+
+    // disable spinner
+    spinner.stop();
+
 }
+
+
+
 
 function show_error(error_text){
     $('#map').hide();
@@ -76,15 +474,3 @@ function show_error(error_text){
     $('#file_error').append(error_text);
 }     
 
-// it is not possible to catch the error of 'parseGeoraster' :\ see: https://github.com/GeoTIFF/georaster/issues/71 
-// in case of not supported tiffs (e.g. Interleaving type "BSQ" with palette) an error is thrown by 'parseGeoraster', but the promise keeps pending :\
-// therefore, after a certain time, it is checked whether the raster has been loaded.
-// if the raster is not loaded, an error is shown..
-function checkIfLoaded() {
-    setTimeout(() => {
-        if(!raster_loaded){
-            show_error("The raster could not be loaded. This may be because it is not a valid GeoTIFF (e.g. projection information is missing). Or the TIFF has a palette with interleaving type 'BSQ', which is not supported.");
-            spinner.stop();
-        }  
-    }, load_timeout * 1000);
-}

--- a/previewers/betatest/js/mapshp.js
+++ b/previewers/betatest/js/mapshp.js
@@ -6,72 +6,113 @@ $(document).ready(function() {
 var map = L.map('map').fitWorld();
 
 function translateBaseHtmlPage() {
-    var mapPreviewText = $.i18n( "mapPreviewText" );
-    $( '.mapPreviewText' ).text( mapPreviewText );
+    $('.mapPreviewText').text($.i18n("mapPreviewText"));
 }
 
 // set limits
-const file_size_limit = 20; // in MB
+const fileSizeLimit = 50; // MB
 
 // enable spinner
 var target = document.getElementById('map');
 var spinner = new Spinner().spin(target);
 
-function writeContent(fileUrl, file, title, authors) {
-    addStandardPreviewHeader(file, title, authors);
 
-    //check file size
-    const url_to_file_info = fileUrl.replace("access/data","").replace("file","files");
+async function loadMetadata(metadataUrl) {
+    const response = await fetch(metadataUrl);
 
-    $.getJSON(url_to_file_info, function( data ) {
-        const file_size = data.data.dataFile.filesize/(1024**2);
+    if (!response.ok) {
+        throw new Error(`HTTP Error: ${response.status}`);
+    }
 
-        if (file_size > file_size_limit){
-            show_error(`The file is too big to be displayed (limit is ${file_size_limit.toString()} MB)`);
-        }else{
-            // load a tile layer
-            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-            }).addTo(map);
-
-            // get data
-            var request = new XMLHttpRequest();
-            request.open('GET', fileUrl, true);
-            request.responseType = 'blob';
-            request.onload = function() {
-                var reader = new FileReader();
-                reader.readAsArrayBuffer(request.response);
-                reader.onload =  function(e){
-                    convertToLayer(e.target.result);        
-                };
-            };
-            request.send();
-        }
-    });
-} 
-
-function convertToLayer(buffer){
-    shp(buffer).then(function(shapeData){	//More info: https://github.com/calvinmetcalf/shapefile-js
-        var shape = L.shapefile(shapeData, {
-        	onEachFeature: function (feature, layer) {
-        	    if (feature.properties) {
-        	        var popupcontent = [];
-        	        for (var propName in feature.properties) {
-        	            propValue = feature.properties[propName];
-        	            popupcontent.push("<strong>" + propName + "</strong>: " + JSON.stringify(propValue, null, 2));
-        	        }
-        	        layer.bindPopup(popupcontent.join("<br />"));
-        	    }
-        	}
-        }).addTo(map);  //More info: https://github.com/calvinmetcalf/leaflet.shapefile
-        map.fitBounds(shape.getBounds()); 
-        // disable spinner
-        spinner.stop();      
-    });
+    return await response.json();
 }
 
-function show_error(error_text){
-	$('#map').hide();
-	$('#file_error').show();
-	$('#file_error').append(error_text);
+
+async function getFileSize() {
+
+    const fileid = queryParams.fileid;
+    const datasetMetadataUrl = queryParams.versionUrl;
+
+    const metadata = await loadMetadata(datasetMetadataUrl);
+
+    const filesMetadata = metadata.data.files;
+
+    const fileMetadata = filesMetadata.find(f => f.dataFile.id === fileid);
+
+    const fileName = fileMetadata.dataFile.filename;
+    const fileSize = Math.round(fileMetadata.dataFile.filesize / (1024 ** 2));
+
+    //console.log(fileName, fileSize);
+
+    return fileSize;
+}
+
+
+async function writeContent(fileUrl, file, title, authors) {
+
+    addStandardPreviewHeader(file, title, authors);
+
+    const fileSize = await getFileSize();
+
+    if (fileSize > fileSizeLimit) {
+        show_error(`The file is too big to be displayed (limit is ${fileSizeLimit} MB)`);
+        spinner.stop();
+        return;
+    }
+
+
+    // load OpenStreetMap tiles
+    L.tileLayer(
+        'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+        {
+            attribution:
+                '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        }
+    ).addTo(map);
+
+
+    try {
+        const buffer = await (
+            await fetch(fileUrl)
+        ).arrayBuffer();
+
+        await convertToLayer(buffer);
+
+    } catch (error) {
+        console.error(error);
+        show_error("Unable to display shapefile.");
+    } finally {
+        spinner.stop();
+    }
+}
+
+
+async function convertToLayer(buffer) {
+
+    // shapefile -> GeoJSON
+    const shapeData = await shp(buffer);
+
+    // GeoJSON -> Leaflet layer
+    const shape = L.geoJSON(shapeData, {
+
+        onEachFeature(feature, layer) {
+            if (!feature.properties) {return;}
+
+            const popupContent = Object.entries(feature.properties)
+                .map(([key, value]) => `<strong>${key}</strong>: ${JSON.stringify(value)}`)
+                .join("<br>");
+
+            layer.bindPopup(popupContent);
+        }
+
+    }).addTo(map);
+
+    map.fitBounds(shape.getBounds());
+}
+    
+
+function show_error(error_text) {
+    $('#map').hide();
+    $('#file_error').show();
+    $('#file_error').append(error_text);
 }


### PR DESCRIPTION
Dear Devs,

I've added a new library (OpenLayers) to my GeoTIFF previewer. This now allows tiled GeoTIFFs and those with pyramid layers (e.g., COG—Cloud Optimized GeoTIFFs) to load quickly! Pyramid layers have downsampled resolutions for different zoom levels, so the entire raster doesn't have to be loaded. This means large GeoTIFFs, even those several GB in size, can be viewed on the fly 🚀

Additional features:
- Supports GeoTIFF and “normal” TIFFs (no custom MIME type required)
- Fast COG rendering (or any tiled GeoTIFFs with pyramid layers)
- Color rendering of grayscale rasters when color palettes are defined (e.g. for classified data)
- Automatic reprojection (using the proj4 library)
- File size limit set to 50 MB if no pyramid layers are present
- Determination of min and max values (if not already available) for stretching

    

Also the shp previewer is updatet (because of #72). Additionally, there was a bug in the new previewer version (v.1.5) where the file size could no longer be read. This is now retrieved from the metadata (queryParams.versionUrl). In the meantime, the code has also been revised, so one less library is needed.

best,
martin